### PR TITLE
feat: Sprint 4 — dry-run / preview mode for all three skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,31 @@ Pass an optional path to target a scoped file: `/refactor-claude-md src/CLAUDE.m
 
 ---
 
+## Preview Modes
+
+All three skills support a preview or read-only mode so you can evaluate what they would do before any files are written.
+
+| Skill | Invocation | What it shows | Side effects |
+|-------|-----------|---------------|-------------|
+| `/refresh-guidelines` | `/refresh-guidelines --preview` | Source list (IDs, URLs, themes) + /insights report summary | None — no network requests, no files written |
+| `/refactor-claude-md` | `/refactor-claude-md --report-only` | Compliance scorecard (pass / partial / fail per category) | None — audit only, no rewrite |
+| `/scaffold-claude-md` | `/scaffold-claude-md --scan-only` | Directory assessment table (RECOMMEND / SKIP / OPTIONAL) | None — scan only, no drafts |
+
+### Examples
+
+```bash
+# See which sources would be fetched before running the full pipeline
+/refresh-guidelines --preview
+
+# Audit compliance of a scoped file without rewriting it
+/refactor-claude-md docs/CLAUDE.md --report-only
+
+# Check which directories would get CLAUDE.md files before reviewing drafts
+/scaffold-claude-md --scan-only
+```
+
+---
+
 ## Skills Reference
 
 | Skill (direct mode) | Skill (plugin mode) | Description |

--- a/skills/refactor-claude-md/SKILL.md
+++ b/skills/refactor-claude-md/SKILL.md
@@ -26,6 +26,8 @@ Audit any `CLAUDE.md` file against the CLAUDE-MD-SOTA guidelines and produce a r
 
 Follow these steps in order. Do NOT skip steps or auto-approve — human review is required.
 
+> **Report-only mode**: If invoked with `--report-only` (e.g., `/refactor-claude-md --report-only` or `/refactor-claude-md docs/CLAUDE.md --report-only`), execute Steps 0–4 only. Present the audit scorecard and stop. Skip Steps 5–7 (approval and file write). This is useful when you want to assess compliance without committing to a rewrite.
+
 ### Step 0: Source selection
 
 Determine which guidelines file to use:

--- a/skills/refresh-guidelines/SKILL.md
+++ b/skills/refresh-guidelines/SKILL.md
@@ -31,6 +31,45 @@ Use the enriched version when writing CLAUDE.md files; fall back to the seed whe
 
 Follow these steps in order. Do NOT skip steps or auto-approve — human review is required.
 
+### Step -1 (optional): Preview mode
+
+If the user invoked the skill with `--preview` (e.g., `/refresh-guidelines --preview`):
+
+1. Run the fetch script in dry-run mode:
+
+```bash
+python3 "$CLAUDE_PLUGIN_ROOT/scripts/fetch-guidelines.py" --dry-run --docs-dir docs
+```
+
+This prints the full list of sources that would be fetched (IDs, URLs, themes) without making any network requests or writing any files.
+
+2. Run the insights parser in dry-run mode:
+
+```bash
+python3 "$CLAUDE_PLUGIN_ROOT/scripts/parse-insights.py" --dry-run --docs-dir docs
+```
+
+This summarises the `/insights` report (age, section count) without writing `docs/insights-parsed.json`.
+
+3. Present the summaries in conversation:
+
+```
+## /refresh-guidelines Preview
+
+### Sources to fetch (N total)
+| ID | Source | Tier | Themes |
+|----|--------|------|--------|
+| T1-001 | Claude Code Memory Management | 1 | structural, content |
+| ...
+
+### /insights report
+Report age: {N} days | Sections available: {N}
+
+No files would be written. Invoke `/refresh-guidelines` (without --preview) to proceed.
+```
+
+4. **Stop. No files are written.** Inform the user they can re-invoke without `--preview` to proceed with the full pipeline.
+
 ### Step 0: Source freshness check
 
 Run the freshness checker to identify stale or broken sources:

--- a/skills/refresh-guidelines/scripts/fetch-guidelines.py
+++ b/skills/refresh-guidelines/scripts/fetch-guidelines.py
@@ -478,16 +478,46 @@ def check_freshness_main(docs_dir: Path) -> int:
 # Main
 # ---------------------------------------------------------------------------
 
-def main(docs_dir: Path | None = None, check_freshness: bool = False) -> int:
+def dry_run_main(docs_dir: Path) -> int:
+    """Entry point for --dry-run mode. Prints source list without fetching or writing."""
+    print(f"fetch-guidelines.py --dry-run — {datetime.now(timezone.utc).isoformat()}",
+          file=sys.stderr)
+
+    if not CURATED_SOURCES.exists():
+        print(f"ERROR: Curated sources not found: {CURATED_SOURCES}", file=sys.stderr)
+        return 1
+
+    sources = parse_curated_sources(CURATED_SOURCES)
+    output_file = docs_dir / "guidelines-raw.json"
+
+    print(f"\nDry-run preview — {len(sources)} sources would be fetched:\n", file=sys.stderr)
+    for source in sources:
+        themes_str = ", ".join(source["themes"]) if source["themes"] else "(no themes)"
+        print(f"  [{source['id']}] {source['source_name']}", file=sys.stderr)
+        print(f"    URL: {source['url']}", file=sys.stderr)
+        print(f"    Themes: {themes_str}", file=sys.stderr)
+
+    print(f"\nWould fetch {len(sources)} sources, would write to {output_file}.",
+          file=sys.stderr)
+    print("No files written (dry-run mode).", file=sys.stderr)
+    return 0
+
+
+def main(docs_dir: Path | None = None, check_freshness: bool = False,
+         dry_run: bool = False) -> int:
     """Fetch content from curated web sources and write to docs_dir.
 
     Args:
         docs_dir: Output directory (default: cwd/docs).
         check_freshness: Run freshness check instead of fetching content.
+        dry_run: Print source list without fetching or writing any files.
 
     Returns 0 on success, 1 on fatal error.
     """
     resolved_docs_dir = docs_dir if docs_dir is not None else Path.cwd() / "docs"
+
+    if dry_run:
+        return dry_run_main(resolved_docs_dir)
 
     if check_freshness:
         return check_freshness_main(resolved_docs_dir)
@@ -579,6 +609,11 @@ if __name__ == "__main__":
         help="Check source URL reachability and staleness instead of fetching content.",
     )
     _parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print source list without fetching or writing any files.",
+    )
+    _parser.add_argument(
         "--docs-dir",
         metavar="PATH",
         help="Directory for output files (default: ./docs relative to cwd).",
@@ -587,4 +622,5 @@ if __name__ == "__main__":
     sys.exit(main(
         docs_dir=_resolve_docs_dir(_args.docs_dir),
         check_freshness=_args.check_freshness,
+        dry_run=_args.dry_run,
     ))

--- a/skills/scaffold-claude-md/SKILL.md
+++ b/skills/scaffold-claude-md/SKILL.md
@@ -25,6 +25,8 @@ Scan a project's directory tree, identify directories that would benefit from a 
 
 Follow these steps in order. Do NOT skip steps or auto-approve — human review is required.
 
+> **Scan-only mode**: If invoked with `--scan-only` (e.g., `/scaffold-claude-md --scan-only`), execute Steps 0–2 only. Present the directory assessment table and stop. Skip Steps 3–6 (draft and write). This is useful when you want to see which directories would receive CLAUDE.md files before reviewing full content drafts.
+
 ### Step 0: Load guidelines
 
 Determine which guidelines file to use:

--- a/tests/test_fetch_behavioral.py
+++ b/tests/test_fetch_behavioral.py
@@ -501,5 +501,56 @@ class TestFreshnessCheckBehavioral(unittest.TestCase):
         self.assertEqual(report["total_sources"], 3)
 
 
+# ===========================================================================
+# 6. dry_run_main() behavioral tests
+# ===========================================================================
+
+
+class TestDryRunMode(unittest.TestCase):
+    """main(dry_run=True) makes no network calls and writes no files."""
+
+    def setUp(self):
+        self.fg = _load_fg()
+        self.tmpdir = Path(tempfile.mkdtemp())
+
+    def test_returns_0(self):
+        with patch.object(self.fg, "parse_curated_sources", return_value=[SAMPLE_SOURCE]):
+            result = self.fg.main(docs_dir=self.tmpdir, dry_run=True)
+        self.assertEqual(result, 0)
+
+    def test_no_files_written(self):
+        with patch.object(self.fg, "parse_curated_sources", return_value=[SAMPLE_SOURCE]):
+            self.fg.main(docs_dir=self.tmpdir, dry_run=True)
+        self.assertFalse((self.tmpdir / "guidelines-raw.json").exists())
+
+    def test_no_http_requests_made(self):
+        with (
+            patch.object(self.fg, "parse_curated_sources", return_value=[SAMPLE_SOURCE]),
+            patch.object(self.fg, "fetch_url") as mock_fetch,
+        ):
+            self.fg.main(docs_dir=self.tmpdir, dry_run=True)
+        mock_fetch.assert_not_called()
+
+    def test_multiple_sources_none_fetched(self):
+        sources = [
+            {**SAMPLE_SOURCE, "id": "T1-001"},
+            {**SAMPLE_SOURCE, "id": "T1-002"},
+            {**SAMPLE_SOURCE, "id": "T1-003"},
+        ]
+        with (
+            patch.object(self.fg, "parse_curated_sources", return_value=sources),
+            patch.object(self.fg, "fetch_url") as mock_fetch,
+        ):
+            result = self.fg.main(docs_dir=self.tmpdir, dry_run=True)
+        self.assertEqual(result, 0)
+        mock_fetch.assert_not_called()
+
+    def test_empty_sources_returns_0(self):
+        with patch.object(self.fg, "parse_curated_sources", return_value=[]):
+            result = self.fg.main(docs_dir=self.tmpdir, dry_run=True)
+        self.assertEqual(result, 0)
+        self.assertFalse((self.tmpdir / "guidelines-raw.json").exists())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  Add no-side-effect preview variants to /refresh-guidelines,
  /refactor-claude-md, and /scaffold-claude-md so users can evaluate
  what each skill will do before any files are written or rewritten.

  Changes:
  - fetch-guidelines.py: add --dry-run flag and dry_run_main() — parses curated-sources.md and prints source list (ID, URL, themes) without making any network requests or writing guidelines-raw.json
  - /refresh-guidelines SKILL.md: add Step -1 (--preview) — runs both scripts in dry-run mode, presents source table + /insights summary, stops without writing anything
  - /refactor-claude-md SKILL.md: add --report-only callout — executes Steps 0-4 (audit scorecard) and stops, skips Steps 5-7 (file write)
  - /scaffold-claude-md SKILL.md: add --scan-only callout — executes Steps 0-2 (directory assessment table) and stops, skips Steps 3-6
  - README.md: add "Preview Modes" section with invocation table and examples for all three preview variants
  - tests/test_fetch_behavioral.py: add TestDryRunMode (5 tests) — verifies dry_run=True returns 0, writes no files, makes no HTTP calls, works with multiple and empty source lists

  All 394 tests pass. ruff clean.

  Sprint 4 success criteria: all five items checked off in
  docs/improvement-plan-v3.3.md.